### PR TITLE
Explicitly initialize UserConfig values to avoid undefined dereference.

### DIFF
--- a/followingcontrol.rb
+++ b/followingcontrol.rb
@@ -3,6 +3,8 @@
 require 'set'
 
 Plugin.create :followingcontrol do
+  UserConfig["retrieve_interval_followings"] ||= 60
+  UserConfig["retrieve_interval_followers"]  ||= 60
 
   counter = gen_counter
 


### PR DESCRIPTION
https://github.com/mikutter/rest/issues/1
で挙がった UserConfig の interval 値の初期値追加です